### PR TITLE
Fix open-ended dependency warning

### DIFF
--- a/docset.gemspec
+++ b/docset.gemspec
@@ -29,9 +29,9 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "sqlite3"
+  spec.add_dependency "sqlite3", "~> 1.3"
   spec.add_development_dependency "bundler", "~> 1.14"
-  spec.add_development_dependency "nokogiri"
+  spec.add_development_dependency "nokogiri", "~> 1.7"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
```
WARNING:  open-ended dependency on sqlite3 (>= 0) is not recommended
  if sqlite3 is semantically versioned, use:
    add_runtime_dependency 'sqlite3', '~> 0'
WARNING:  open-ended dependency on nokogiri (>= 0, development) is not recommended
  if nokogiri is semantically versioned, use:
    add_development_dependency 'nokogiri', '~> 0'
WARNING:  See http://guides.rubygems.org/specification-reference/ for help
```