### PR TITLE
Fix allowed_push_host

### DIFF
--- a/docset.gemspec
+++ b/docset.gemspec
@@ -13,15 +13,6 @@ Gem::Specification.new do |spec|
   spec.homepage      = "https://github.com/yasslab/docset"
   spec.license       = "MIT"
 
-  # Prevent pushing this gem to RubyGems.org. To allow pushes either set the 'allowed_push_host'
-  # to allow pushing to a single host or delete this section to allow pushing to any host.
-  if spec.respond_to?(:metadata)
-    spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
-  else
-    raise "RubyGems 2.0 or newer is required to protect against " \
-      "public gem pushes."
-  end
-
   spec.files         = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|spec|features)/})
   end


### PR DESCRIPTION
```
rake aborted!
ERROR:  While executing gem ... (Gem::CommandLineError)
    Too many gem names (/Users/sei/src/github.com/yasslab/docset/pkg/docset-0.1.0.gem, Set, to, http://mygemserver.com); please specify only one
/usr/local/var/rbenv/versions/2.4.1/bin/bundle:22:in `load'
/usr/local/var/rbenv/versions/2.4.1/bin/bundle:22:in `<main>'
Tasks: TOP => release => release:rubygem_push
(See full trace by running task with --trace)
```